### PR TITLE
Changing how the plots are generated and provisioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2 - 2022-06-21
+- [GP-2981](https://jira.oicr.on.ca/browse/GP-2981) moving to research, revised how segmentation image is produced
 ## Unreleased - 2021-11-10
 - [GP-2879](https://jira.oicr.on.ca/browse/GP-2879) make calculate script more robust
 ## 2.0.1 - 2021-06-02

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Output | Type | Description
 ---|---|---
 `resultiSegFile`|File|.seg file produced with HMMcopy
 `resultTsvFile`|File|.tsv file with all calls produced by HMMcopy
-`zippedPlots`|File|zipped plots in .png format
-
+`segImage`|File|image file (segmentation plot) in .png format
+`cgBiasImage`|File|image file with CG bias results in .png format
 
 ## Commands
  This section lists command(s) run by hmmcopy workflow

--- a/hmmcopy.wdl
+++ b/hmmcopy.wdl
@@ -35,7 +35,8 @@ meta {
     output_meta: {
       resultiSegFile: ".seg file produced with HMMcopy",
       resultTsvFile: ".tsv file with all calls produced by HMMcopy",
-      zippedPlots: "zipped plots in .png format"
+      cgBiasImage: "Plot showing the results of CG bias test",
+      segImage: "Plot shows the segmentation data"
     }
 }
 
@@ -48,7 +49,9 @@ parameter_meta {
 output {
   File resultiSegFile = runHMMcopy.segFile
   File resultTsvFile  = runHMMcopy.tsvFile
-  File zippedPlots    = runHMMcopy.zippedPlots
+  File cgBiasImage    = runHMMcopy.cgBiasImage
+  File segImage       = runHMMcopy.segImage
+
 }
 
 }
@@ -139,7 +142,8 @@ runtime {
 output {
   File segFile = "~{outputPrefix}.seg"
   File tsvFile = "~{outputPrefix}.tsv"
-  File zippedPlots = "~{outputPrefix}_images.zip"
+  File cgBiasImage = "~{outputPrefix}.bias_plot.png"
+  File segImage = "~{outputPrefix}.s_plot.png"
 }
 }
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -36,7 +36,7 @@
             "hmmcopy.runHMMcopy.hmmcopyScript": null,
             "hmmcopy.runHMMcopy.jobMemory": null,
             "hmmcopy.runHMMcopy.mapFile": "/.mounts/labs/gsi/testdata/hmmcopy/hmmcopy_data/map_hg18_chr22.wig",
-            "hmmcopy.runHMMcopy.modules": "hmmcopy/1.28.1 hmmcopy-scripts/1.0 rstats-cairo/3.6",
+            "hmmcopy.runHMMcopy.modules": "hmmcopy/1.28.1 hmmcopy-scripts/1.1 rstats-cairo/3.6",
             "hmmcopy.runHMMcopy.rScript": null,
             "hmmcopy.runHMMcopy.timeout": null,
             "hmmcopy.tumorConvert.chromosomes": null,
@@ -69,7 +69,15 @@
                 ],
                 "type": "ALL"
             },
-            "hmmcopy.zippedPlots": {
+            "hmmcopy.cgBiasImage": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_hmmcopy_TEST_CHR22_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "hmmcopy.segImage": {
                 "contents": [
                     {
                         "outputDirectory": "@SCRATCH@/@DATE@_Workflow_hmmcopy_TEST_CHR22_@JENKINSID@"


### PR DESCRIPTION
In this update we are changing how the images (Segmentation plot) are produced. Before we were providing one plot per chromosome, but as it turns out the **HMMcopy** script produces one plot only (for everything). The script that makes this type of plot is probably meant for some downstream custom visualization where you specify a region of interest. Bottom line - we now have a set of outputs which is different from the previous version. This will be deployed in research as a "new" workflow